### PR TITLE
Bump paypalhttp-java dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 .idea/
 *.class
 .gradle
+.classpath
+.project
+.settings
+build/
+checkout-sdk-sample/
 
 # Created by https://www.gitignore.io/api/java
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .project
 .settings
 build/
-checkout-sdk-sample/
 
 # Created by https://www.gitignore.io/api/java
 

--- a/README.md
+++ b/README.md
@@ -142,9 +142,6 @@ To run integration tests using your client id and secret, run the `test` gradle 
 $ PAYPAL_CLIENT_ID=your_client_id PAYPAL_CLIENT_SECRET=your_client_secret ./gradlew clean test -Pintegration
 ```
 
-You may use the client id and secret above for demonstration purposes.
-
-
 ## Samples
 
 You can start off by trying out [creating and capturing an order](/checkout-sdk-sample/src/main/java/com/paypal/CaptureIntentExamples/RunAll.java).

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
      }
 
      dependencies {
-         compile ("com.paypal:paypalhttp:1.0.3")
+         compile ("com.paypal:paypalhttp:2.0.0")
 		 testCompile group: 'org.testng', name: 'testng', version: '6.9.13.6'
          testCompile "com.github.tomakehurst:wiremock:2.4.1"
      }

--- a/checkout-sdk/src/test/java/com/paypal/TestHarness.java
+++ b/checkout-sdk/src/test/java/com/paypal/TestHarness.java
@@ -7,22 +7,22 @@ import org.testng.annotations.BeforeMethod;
 
 public class TestHarness {
 
-    private HttpClient client;
-    private PayPalEnvironment environment;
+  private HttpClient client;
+  private PayPalEnvironment environment;
 
-    @BeforeMethod
-    public void setup() {
-        environment = new PayPalEnvironment.Sandbox(
-                "AdV4d6nLHabWLyemrw4BKdO9LjcnioNIOgoz7vD611ObbDUL0kJQfzrdhXEBwnH8QmV-7XZjvjRWn0kg",
-                "EPKoPC_haZMTq5uM9WXuzoxUVdgzVqHyD5avCyVC1NCIUJeVaNNUZMnzduYIqrdw-carG9LBAizFGMyK");
-        client = new PayPalHttpClient(environment);
-    }
+  @BeforeMethod
+  public void setup() {
+    environment = new PayPalEnvironment.Sandbox(
+      System.getenv("PAYPAL_CLIENT_ID"),
+      System.getenv("PAYPAL_CLIENT_SECRET"));
+    client = new PayPalHttpClient(environment);
+  }
 
-    protected HttpClient client() {
-        return client;
-    }
+  protected HttpClient client() {
+    return client;
+  }
 
-    protected PayPalEnvironment environment() {
-        return environment;
-    }
+  protected PayPalEnvironment environment() {
+    return environment;
+  }
 }


### PR DESCRIPTION
* Add additional files to .gitignore
* Update test harness to respect README env vars for test runs

Because this bumps the `paypalhttp_java` dependency to 2.0.0 and the `PayPalHttpClient` here extends the HttpClient from that lib, it stands to reason that this change would technically also require a major version bump as it would also now return a different exception in the case of an error parsing JSON payloads.